### PR TITLE
Fix escaping in Linux filter_region.

### DIFF
--- a/plat/linux.py
+++ b/plat/linux.py
@@ -10,9 +10,14 @@ def run_and_wait(view, cmd):
             "bash -c \"%s; read -p 'Press RETURN to exit.'\"" % cmd]).wait()
 
 
+def bash_escape_double_quoted_text(text):
+    return text.replace('\\', '\\\\').replace('"', '\\"').replace('$', '\\$')
+
+
 def filter_region(view, text, command):
     shell = view.settings().get('vintageex_linux_shell')
     shell = shell or os.path.expandvars("$SHELL")
-    p = subprocess.Popen([shell, '-c', 'echo "%s" | %s' % (text, command)],
+    escaped = bash_escape_double_quoted_text(text)
+    p = subprocess.Popen([shell, '-c', 'echo "%s" | %s' % (escaped, command)],
                          stdout=subprocess.PIPE)
     return p.communicate()[0][:-1]


### PR DESCRIPTION
Text that gets filtered through a command (e.g. with `:'<,'>!tr x y`)
is interpolated between double quotes in a command string. If the text
in question contained double quotes, backslashes, or dollar signs
(which indicate variable or shell interpolation), the shell would parse
them as special characters, usually failing.

This patch adds a bash_escape_double_quoted_text function that escapes
those characters in the text getting filtered, so that the shell treats
them as plain.
